### PR TITLE
Replication of original PR #594: Add support for sentinels (PEP 661)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ New features:
   Patch by [Victorien Plot](https://github.com/Viicos).
 - Add `typing_extensions.Reader` and `typing_extensions.Writer`. Patch by
   Sebastian Rittau.
+- Add support for sentinels ([PEP 661](https://peps.python.org/pep-0661/)). Patch by
+  [Victorien Plot](https://github.com/Viicos).
 
 # Release 4.13.2 (April 10, 2025)
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1027,6 +1027,34 @@ Capsule objects
    .. versionadded:: 4.12.0
 
 
+Sentinel objects
+~~~~~~~~~~~~~~~~
+
+.. class:: Sentinel(name, repr=None)
+
+   A type used to define sentinel values. The *name* argument should be the
+   name of the variable to which the return value shall be assigned.
+
+   If *repr* is provided, it will be used for the :meth:`~object.__repr__`
+   of the sentinel object. If not provided, ``"<name>"`` will be used.
+
+   Example::
+
+      >>> from typing_extensions import Sentinel, assert_type
+      >>> MISSING = Sentinel('MISSING')
+      >>> def func(arg: int | MISSING = MISSING) -> None:
+      ...     if arg is MISSING:
+      ...         assert_type(arg, MISSING)
+      ...     else:
+      ...         assert_type(arg, int)
+      ...
+      >>> func(MISSING)
+
+   .. versionadded:: 4.14.0
+
+      See :pep:`661`
+
+
 Pure aliases
 ~~~~~~~~~~~~
 

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -89,6 +89,7 @@ __all__ = [
     'overload',
     'override',
     'Protocol',
+    'Sentinel',
     'reveal_type',
     'runtime',
     'runtime_checkable',
@@ -4208,6 +4209,42 @@ else:
             format=format,
             owner=owner,
         )
+
+
+class Sentinel:
+    """Create a unique sentinel object.
+
+    *name* should be the name of the variable to which the return value shall be assigned.
+
+    *repr*, if supplied, will be used for the repr of the sentinel object.
+    If not provided, "<name>" will be used.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        repr: typing.Optional[str] = None,
+    ):
+        self._name = name
+        self._repr = repr if repr is not None else f'<{name}>'
+
+    def __repr__(self):
+        return self._repr
+
+    if sys.version_info < (3, 11):
+        # The presence of this method convinces typing._type_check
+        # that Sentinels are types.
+        def __call__(self, *args, **kwargs):
+            raise TypeError(f"{type(self).__name__!r} object is not callable")
+
+    def __or__(self, other):
+        return typing.Union[self, other]
+
+    def __ror__(self, other):
+        return typing.Union[other, self]
+
+    def __getstate__(self):
+        raise TypeError(f"Cannot pickle {type(self).__name__!r} object")
 
 
 # Aliases for items that are in typing in all supported versions.


### PR DESCRIPTION
# PR Summary

Add Sentinel class for unique typing sentinel objects

## Overview

This PR adds a new `Sentinel` class to create unique sentinel objects for typing purposes, with special handling for Python versions before 3.11. The class is exposed as a public API and includes comprehensive test coverage.

## Change Types

| Type         | Description                            |
|--------------|----------------------------------------|
| Feature      | New `Sentinel` class for typing purposes |
| Test         | Test cases for the new `Sentinel` class |

---

## Affected Modules

| Module / File                | Change Description                       |
|------------------------------|------------------------------------------|
| `typing_extensions.py`       | Added new `Sentinel` class and exposed it in `__all__` |
| `test_typing_extensions.py`  | Added import and test cases for `Sentinel` class |

## Notes for Reviewers

* Special handling is implemented for Python versions before 3.11
* Tests cover representation, type expression unions, non-callable behavior, and non-picklable behavior