### PR TITLE
Replication of original PR #595: Become robust to things being removed from typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 
 - Drop support for Python 3.8 (including PyPy-3.8). Patch by [Victorien Plot](https://github.com/Viicos).
+- Do not attempt to re-export names that have been removed from `typing`,
+  anticipating the removal of `typing.no_type_check_decorator` in Python 3.15.
 
 New features:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,9 @@ ignore = [
     "RUF012",
     "RUF022",
     "RUF023",
+    # Ruff doesn't understand the globals() assignment; we test __all__
+    # directly in test_all_names_in___all__.
+    "F822",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/src/test_typing_extensions.py
+++ b/src/test_typing_extensions.py
@@ -6827,6 +6827,15 @@ class AllTests(BaseTestCase):
                     getattr(typing_extensions, item),
                     getattr(typing, item))
 
+    def test_alias_names_still_exist(self):
+        for name in typing_extensions._typing_names:
+            # If this fails, change _typing_names to conditionally add the name
+            # depending on the Python version.
+            self.assertTrue(
+                hasattr(typing_extensions, name),
+                f"{name} no longer exists in typing",
+            )
+
     def test_typing_extensions_compiles_with_opt(self):
         file_path = typing_extensions.__file__
         try:

--- a/src/typing_extensions.py
+++ b/src/typing_extensions.py
@@ -4223,46 +4223,52 @@ else:
 
 
 # Aliases for items that are in typing in all supported versions.
-# Explicitly assign these (rather than using `from typing import *` at the top),
-# so that we get a CI error if one of these is deleted from typing.py
-# in a future version of Python
-AbstractSet = typing.AbstractSet
-Annotated = typing.Annotated
-AnyStr = typing.AnyStr
-BinaryIO = typing.BinaryIO
-Callable = typing.Callable
-Collection = typing.Collection
-Container = typing.Container
-Dict = typing.Dict
-ForwardRef = typing.ForwardRef
-FrozenSet = typing.FrozenSet
+# We use hasattr() checks so this library will continue to import on
+# future versions of Python that may remove these names.
+_typing_names = [
+    "AbstractSet",
+    "AnyStr",
+    "BinaryIO",
+    "Callable",
+    "Collection",
+    "Container",
+    "Dict",
+    "FrozenSet",
+    "Hashable",
+    "IO",
+    "ItemsView",
+    "Iterable",
+    "Iterator",
+    "KeysView",
+    "List",
+    "Mapping",
+    "MappingView",
+    "Match",
+    "MutableMapping",
+    "MutableSequence",
+    "MutableSet",
+    "Optional",
+    "Pattern",
+    "Reversible",
+    "Sequence",
+    "Set",
+    "Sized",
+    "TextIO",
+    "Tuple",
+    "Union",
+    "ValuesView",
+    "cast",
+    "no_type_check",
+    "no_type_check_decorator",
+    # This is private, but it was defined by typing_extensions for a long time
+    # and some users rely on it.
+    "_AnnotatedAlias",
+]
+globals().update(
+    {name: getattr(typing, name) for name in _typing_names if hasattr(typing, name)}
+)
+# These are defined unconditionally because they are used in
+# typing-extensions itself.
 Generic = typing.Generic
-Hashable = typing.Hashable
-IO = typing.IO
-ItemsView = typing.ItemsView
-Iterable = typing.Iterable
-Iterator = typing.Iterator
-KeysView = typing.KeysView
-List = typing.List
-Mapping = typing.Mapping
-MappingView = typing.MappingView
-Match = typing.Match
-MutableMapping = typing.MutableMapping
-MutableSequence = typing.MutableSequence
-MutableSet = typing.MutableSet
-Optional = typing.Optional
-Pattern = typing.Pattern
-Reversible = typing.Reversible
-Sequence = typing.Sequence
-Set = typing.Set
-Sized = typing.Sized
-TextIO = typing.TextIO
-Tuple = typing.Tuple
-Union = typing.Union
-ValuesView = typing.ValuesView
-cast = typing.cast
-no_type_check = typing.no_type_check
-no_type_check_decorator = typing.no_type_check_decorator
-# This is private, but it was defined by typing_extensions for a long time
-# and some users rely on it.
-_AnnotatedAlias = typing._AnnotatedAlias
+ForwardRef = typing.ForwardRef
+Annotated = typing.Annotated


### PR DESCRIPTION
# PR Summary

Improve typing aliases import mechanism for better Python version compatibility

## Overview

This PR changes how typing aliases are imported from the typing module to use dynamic imports with hasattr() checks, improving compatibility with future Python versions. It also adds tests to verify all typing names remain accessible.

## Change Types

| Type         | Description                            |
|--------------|----------------------------------------|
| Enhancement  | Improved import mechanism for typing aliases |
| Test         | Added test to verify typing name accessibility |

---

## Affected Modules

| Module / File          | Change Description                       |
|------------------------|------------------------------------------|
| `typing_extensions.py` | Changed to dynamic imports with hasattr() checks |
| `test_typing_extensions.py` | Added test for typing name accessibility |

## Notes for Reviewers

* The change to dynamic imports should maintain backward compatibility while improving future compatibility
* Verify the new test correctly validates all typing names are accessible